### PR TITLE
tutorials_feti-ex1_% requires mumps.

### DIFF
--- a/src/tutorials/feti/ex1.c
+++ b/src/tutorials/feti/ex1.c
@@ -116,6 +116,7 @@ int main(int argc,char **args)
 /*TEST
   testset:
     nsize: 4
+    requires: mumps
     filter: grep -e CONVERGED -e "r ="
     args: -ne 7 -qp_chain_view_kkt -qpt_matis_to_diag_norm
     test:


### PR DESCRIPTION
Fix #32.