### PR TITLE
QPS: Reduce number of arguments of convergence tests.

### DIFF
--- a/include/permon/private/qpsimpl.h
+++ b/include/permon/private/qpsimpl.h
@@ -44,7 +44,7 @@ struct _p_QPS {
   PetscObjectState xstate;
   
   /* convergence tests */  
-  PetscErrorCode   (*convergencetest)(QPS,QP,PetscInt,PetscReal,KSPConvergedReason*,void*);
+  PetscErrorCode   (*convergencetest)(QPS,KSPConvergedReason*,void*);
   PetscErrorCode   (*convergencetestdestroy)(void*);
   void             *cnvctx;
 

--- a/include/permon/private/qpsimpl.h
+++ b/include/permon/private/qpsimpl.h
@@ -44,7 +44,7 @@ struct _p_QPS {
   PetscObjectState xstate;
   
   /* convergence tests */  
-  PetscErrorCode   (*convergencetest)(QPS,KSPConvergedReason*,void*);
+  PetscErrorCode   (*convergencetest)(QPS,KSPConvergedReason*);
   PetscErrorCode   (*convergencetestdestroy)(void*);
   void             *cnvctx;
 

--- a/include/permonqps.h
+++ b/include/permonqps.h
@@ -45,7 +45,7 @@ FLLOP_EXTERN PetscErrorCode QPSSetQP(QPS qps,QP qp);
 FLLOP_EXTERN PetscErrorCode QPSSetTolerances(QPS qps,PetscReal rtol,PetscReal abstol,PetscReal dtol,PetscInt maxits);
 FLLOP_EXTERN PetscErrorCode QPSSetOptionsPrefix(QPS qps,const char prefix[]);
 FLLOP_EXTERN PetscErrorCode QPSAppendOptionsPrefix(QPS qps,const char prefix[]);
-FLLOP_EXTERN PetscErrorCode QPSSetConvergenceTest(QPS qps,PetscErrorCode (*converge)(QPS,KSPConvergedReason*,void*),void *cctx,PetscErrorCode (*destroy)(void*));
+FLLOP_EXTERN PetscErrorCode QPSSetConvergenceTest(QPS qps,PetscErrorCode (*converge)(QPS,KSPConvergedReason*),void *cctx,PetscErrorCode (*destroy)(void*));
 FLLOP_EXTERN PetscErrorCode QPSSetAutoPostSolve(QPS qps,PetscBool flg);
 
 FLLOP_EXTERN PetscErrorCode QPSGetType(QPS qps,const QPSType *type);
@@ -61,9 +61,9 @@ FLLOP_EXTERN PetscErrorCode QPSGetAccumulatedIterationNumber(QPS qps,PetscInt *i
 FLLOP_EXTERN PetscErrorCode QPSGetAutoPostSolve(QPS qps,PetscBool *flg);
 FLLOP_EXTERN PetscErrorCode QPSGetVecs(QPS qps,PetscInt rightn, Vec **right,PetscInt leftn,Vec **left);
 
-FLLOP_EXTERN PetscErrorCode QPSConvergedSkip(QPS qps,KSPConvergedReason *reason,void *ctx);
-FLLOP_EXTERN PetscErrorCode QPSConvergedDefault(QPS qps,KSPConvergedReason *reason,void*);
-FLLOP_EXTERN PetscErrorCode QPSConvergedDefaultSetUp(void *ctx, QPS qps);
+FLLOP_EXTERN PetscErrorCode QPSConvergedSkip(QPS qps,KSPConvergedReason *reason);
+FLLOP_EXTERN PetscErrorCode QPSConvergedDefault(QPS qps,KSPConvergedReason *reason);
+FLLOP_EXTERN PetscErrorCode QPSConvergedDefaultSetUp(QPS qps);
 FLLOP_EXTERN PetscErrorCode QPSConvergedDefaultSetRhsForDivergence(void *cctx, Vec b);
 FLLOP_EXTERN PetscErrorCode QPSConvergedDefaultDestroy(void *);
 FLLOP_EXTERN PetscErrorCode QPSConvergedDefaultCreate(void **);

--- a/include/permonqps.h
+++ b/include/permonqps.h
@@ -45,7 +45,7 @@ FLLOP_EXTERN PetscErrorCode QPSSetQP(QPS qps,QP qp);
 FLLOP_EXTERN PetscErrorCode QPSSetTolerances(QPS qps,PetscReal rtol,PetscReal abstol,PetscReal dtol,PetscInt maxits);
 FLLOP_EXTERN PetscErrorCode QPSSetOptionsPrefix(QPS qps,const char prefix[]);
 FLLOP_EXTERN PetscErrorCode QPSAppendOptionsPrefix(QPS qps,const char prefix[]);
-FLLOP_EXTERN PetscErrorCode QPSSetConvergenceTest(QPS qps,PetscErrorCode (*converge)(QPS,QP,PetscInt,PetscReal,KSPConvergedReason*,void*),void *cctx,PetscErrorCode (*destroy)(void*));
+FLLOP_EXTERN PetscErrorCode QPSSetConvergenceTest(QPS qps,PetscErrorCode (*converge)(QPS,KSPConvergedReason*,void*),void *cctx,PetscErrorCode (*destroy)(void*));
 FLLOP_EXTERN PetscErrorCode QPSSetAutoPostSolve(QPS qps,PetscBool flg);
 
 FLLOP_EXTERN PetscErrorCode QPSGetType(QPS qps,const QPSType *type);
@@ -61,8 +61,8 @@ FLLOP_EXTERN PetscErrorCode QPSGetAccumulatedIterationNumber(QPS qps,PetscInt *i
 FLLOP_EXTERN PetscErrorCode QPSGetAutoPostSolve(QPS qps,PetscBool *flg);
 FLLOP_EXTERN PetscErrorCode QPSGetVecs(QPS qps,PetscInt rightn, Vec **right,PetscInt leftn,Vec **left);
 
-FLLOP_EXTERN PetscErrorCode QPSConvergedSkip(QPS qps,QP qp,PetscInt i,PetscReal rnorm,KSPConvergedReason *reason,void *ctx);
-FLLOP_EXTERN PetscErrorCode QPSConvergedDefault(QPS qps,QP qp,PetscInt i,PetscReal rnorm,KSPConvergedReason *reason,void*);
+FLLOP_EXTERN PetscErrorCode QPSConvergedSkip(QPS qps,KSPConvergedReason *reason,void *ctx);
+FLLOP_EXTERN PetscErrorCode QPSConvergedDefault(QPS qps,KSPConvergedReason *reason,void*);
 FLLOP_EXTERN PetscErrorCode QPSConvergedDefaultSetUp(void *ctx, QPS qps);
 FLLOP_EXTERN PetscErrorCode QPSConvergedDefaultSetRhsForDivergence(void *cctx, Vec b);
 FLLOP_EXTERN PetscErrorCode QPSConvergedDefaultDestroy(void *);

--- a/src/qps/impls/ksp/qpsksp.c
+++ b/src/qps/impls/ksp/qpsksp.c
@@ -8,7 +8,9 @@ static PetscErrorCode QPSKSPConverged_KSP(KSP ksp,PetscInt i,PetscReal rnorm,KSP
   QPS qps = (QPS) ctx;
 
   PetscFunctionBegin;
-  TRY( (*qps->convergencetest)(qps,qps->solQP,i,rnorm,reason,qps->cnvctx) );
+  qps->iteration = i;
+  qps->rnorm = rnorm;
+  TRY( (*qps->convergencetest)(qps,reason,qps->cnvctx) );
   PetscFunctionReturn(0);
 }
 

--- a/src/qps/impls/ksp/qpsksp.c
+++ b/src/qps/impls/ksp/qpsksp.c
@@ -10,7 +10,7 @@ static PetscErrorCode QPSKSPConverged_KSP(KSP ksp,PetscInt i,PetscReal rnorm,KSP
   PetscFunctionBegin;
   qps->iteration = i;
   qps->rnorm = rnorm;
-  TRY( (*qps->convergencetest)(qps,reason,qps->cnvctx) );
+  TRY( (*qps->convergencetest)(qps,reason) );
   PetscFunctionReturn(0);
 }
 

--- a/src/qps/impls/mpgp/mpgp.c
+++ b/src/qps/impls/mpgp/mpgp.c
@@ -350,7 +350,7 @@ PetscErrorCode QPSSolve_MPGP(QPS qps)
     }
 
     /* test the convergence of algorithm */
-    TRY( (*qps->convergencetest)(qps,&qps->reason,qps->cnvctx) ); /* test for convergence */
+    TRY( (*qps->convergencetest)(qps,&qps->reason) ); /* test for convergence */
     if (qps->reason != KSP_CONVERGED_ITERATING) break;
     
     /* proportional condition */

--- a/src/qps/impls/mpgp/mpgp.c
+++ b/src/qps/impls/mpgp/mpgp.c
@@ -350,7 +350,7 @@ PetscErrorCode QPSSolve_MPGP(QPS qps)
     }
 
     /* test the convergence of algorithm */
-    TRY( (*qps->convergencetest)(qps,qp,qps->iteration,qps->rnorm,&qps->reason,qps->cnvctx) ); /* test for convergence */
+    TRY( (*qps->convergencetest)(qps,&qps->reason,qps->cnvctx) ); /* test for convergence */
     if (qps->reason != KSP_CONVERGED_ITERATING) break;
     
     /* proportional condition */

--- a/src/qps/impls/pcpg/pcpg.c
+++ b/src/qps/impls/pcpg/pcpg.c
@@ -104,7 +104,7 @@ PetscErrorCode QPSSolve_PCPG(QPS qps){
     
     //convergence test
     TRY( VecNorm(w, NORM_2, &qps->rnorm) );
-    TRY( (*qps->convergencetest)(qps,&qps->reason,qps->cnvctx) );
+    TRY( (*qps->convergencetest)(qps,&qps->reason) );
     if (qps->reason) break;
     
     if (pcnone) {

--- a/src/qps/impls/pcpg/pcpg.c
+++ b/src/qps/impls/pcpg/pcpg.c
@@ -104,7 +104,7 @@ PetscErrorCode QPSSolve_PCPG(QPS qps){
     
     //convergence test
     TRY( VecNorm(w, NORM_2, &qps->rnorm) );
-    TRY( (*qps->convergencetest)(qps,qp,qps->iteration,qps->rnorm,&qps->reason,qps->cnvctx) );
+    TRY( (*qps->convergencetest)(qps,&qps->reason,qps->cnvctx) );
     if (qps->reason) break;
     
     if (pcnone) {

--- a/src/qps/impls/smalxe/smalxe.c
+++ b/src/qps/impls/smalxe/smalxe.c
@@ -616,9 +616,9 @@ PETSC_STATIC_INLINE PetscErrorCode QPSConverged_Inner_SMALXE_Monitor_Inner(QPS q
 
 #undef __FUNCT__
 #define __FUNCT__ "QPSConverged_Inner_SMALXE"
-PetscErrorCode QPSConverged_Inner_SMALXE(QPS qps_inner,KSPConvergedReason *reason,void *ctx)
+PetscErrorCode QPSConverged_Inner_SMALXE(QPS qps_inner,KSPConvergedReason *reason)
 {
-  QPSConvergedCtx_Inner_SMALXE *cctx = (QPSConvergedCtx_Inner_SMALXE*) ctx;
+  QPSConvergedCtx_Inner_SMALXE *cctx = (QPSConvergedCtx_Inner_SMALXE*) qps_inner->cnvctx;
   QPS qps_outer = cctx->qps_outer;
   QPS_SMALXE *smalxe = (QPS_SMALXE*)qps_outer->data;
   QP qp_inner = qps_inner->solQP;
@@ -655,7 +655,7 @@ PetscErrorCode QPSConverged_Inner_SMALXE(QPS qps_inner,KSPConvergedReason *reaso
   }
 
   
-  TRY( (*qps_outer->convergencetest)(qps_outer,&qps_outer->reason,qps_outer->cnvctx) );
+  TRY( (*qps_outer->convergencetest)(qps_outer,&qps_outer->reason) );
 
   if (qps_outer->reason) {
     if (qps_outer->reason > 0) {

--- a/src/qps/impls/smalxe/smalxeimpl.h
+++ b/src/qps/impls/smalxe/smalxeimpl.h
@@ -69,7 +69,7 @@ typedef struct {
 FLLOP_EXTERN PetscErrorCode QPSCreate_SMALXE(QPS qps);
 FLLOP_INTERN PetscErrorCode QPSSetFromOptions_SMALXE(PetscOptionItems *PetscOptionsObject,QPS qps);
 FLLOP_INTERN PetscErrorCode QPSSetUp_SMALXE(QPS qps);
-FLLOP_INTERN PetscErrorCode QPSConverged_Inner_SMALXE(QPS qps_inner,QP qp_inner,PetscInt i,PetscReal rnorm_inner,KSPConvergedReason *reason,void *ctx);
+FLLOP_INTERN PetscErrorCode QPSConverged_Inner_SMALXE(QPS qps_inner,KSPConvergedReason *reason,void *ctx);
 FLLOP_INTERN PetscErrorCode QPSConvergedSetUp_Inner_SMALXE(QPS qps_inner);
 FLLOP_INTERN PetscErrorCode QPSConvergedCreate_Inner_SMALXE(QPS qps_outer, void **ctx);
 FLLOP_INTERN PetscErrorCode QPSConvergedDestroy_Inner_SMALXE(void *ctx);

--- a/src/qps/impls/smalxe/smalxeimpl.h
+++ b/src/qps/impls/smalxe/smalxeimpl.h
@@ -69,7 +69,7 @@ typedef struct {
 FLLOP_EXTERN PetscErrorCode QPSCreate_SMALXE(QPS qps);
 FLLOP_INTERN PetscErrorCode QPSSetFromOptions_SMALXE(PetscOptionItems *PetscOptionsObject,QPS qps);
 FLLOP_INTERN PetscErrorCode QPSSetUp_SMALXE(QPS qps);
-FLLOP_INTERN PetscErrorCode QPSConverged_Inner_SMALXE(QPS qps_inner,KSPConvergedReason *reason,void *ctx);
+FLLOP_INTERN PetscErrorCode QPSConverged_Inner_SMALXE(QPS qps_inner,KSPConvergedReason *reason);
 FLLOP_INTERN PetscErrorCode QPSConvergedSetUp_Inner_SMALXE(QPS qps_inner);
 FLLOP_INTERN PetscErrorCode QPSConvergedCreate_Inner_SMALXE(QPS qps_outer, void **ctx);
 FLLOP_INTERN PetscErrorCode QPSConvergedDestroy_Inner_SMALXE(void *ctx);

--- a/src/qps/impls/tao/qpstao.c
+++ b/src/qps/impls/tao/qpstao.c
@@ -12,7 +12,7 @@ static PetscErrorCode QPSTaoConverged_Tao(Tao tao,void *ctx)
   //TODO sqrt?
   qps->rnorm = tao->residual;
   qps->iteration = tao->niter;
-  TRY( (*qps->convergencetest)(qps,&qps->reason,qps->cnvctx) );
+  TRY( (*qps->convergencetest)(qps,&qps->reason) );
 
   //TODO quick&dirty
   if (qps->reason > 0) {

--- a/src/qps/impls/tao/qpstao.c
+++ b/src/qps/impls/tao/qpstao.c
@@ -12,7 +12,7 @@ static PetscErrorCode QPSTaoConverged_Tao(Tao tao,void *ctx)
   //TODO sqrt?
   qps->rnorm = tao->residual;
   qps->iteration = tao->niter;
-  TRY( (*qps->convergencetest)(qps,qps->solQP,qps->iteration,qps->rnorm,&qps->reason,qps->cnvctx) );
+  TRY( (*qps->convergencetest)(qps,&qps->reason,qps->cnvctx) );
 
   //TODO quick&dirty
   if (qps->reason > 0) {

--- a/src/qps/interface/qps.c
+++ b/src/qps/interface/qps.c
@@ -690,7 +690,6 @@ PetscErrorCode QPSConvergedDefault(QPS qps,KSPConvergedReason *reason,void *ctx)
 
   PetscFunctionBegin;
   PetscValidHeaderSpecific(qps,QPS_CLASSID,1);
-  PetscValidHeaderSpecific(qp,QP_CLASSID,2);
   *reason = KSP_CONVERGED_ITERATING;
 
   if (!qps->setupcalled) FLLOP_SETERRQ(((PetscObject) qps)->comm, PETSC_ERR_ARG_WRONGSTATE, "QPSSetUp() not yet called");

--- a/src/qps/interface/qps.c
+++ b/src/qps/interface/qps.c
@@ -621,7 +621,7 @@ PetscErrorCode QPSPostSolve(QPS qps)
 
 #undef __FUNCT__  
 #define __FUNCT__ "QPSSetConvergenceTest"
-PetscErrorCode QPSSetConvergenceTest(QPS qps,PetscErrorCode (*converge)(QPS,KSPConvergedReason*,void*),void *cctx,PetscErrorCode (*destroy)(void*))
+PetscErrorCode QPSSetConvergenceTest(QPS qps,PetscErrorCode (*converge)(QPS,KSPConvergedReason*),void *cctx,PetscErrorCode (*destroy)(void*))
 {
   PetscFunctionBegin;
   PetscValidHeaderSpecific(qps,QPS_CLASSID,1);
@@ -681,9 +681,9 @@ $      rnorm > dtol * rnorm_0,
 .seealso: QPSSetConvergenceTest(), QPSSetTolerances(), QPSConvergedSkip(), KSPConvergedReason, QPSGetConvergedReason(),
           QPSConvergedDefaultCreate(), QPSConvergedDefaultDestroy()
 @*/
-PetscErrorCode QPSConvergedDefault(QPS qps,KSPConvergedReason *reason,void *ctx)
+PetscErrorCode QPSConvergedDefault(QPS qps,KSPConvergedReason *reason)
 {
-  QPSConvergedDefaultCtx *cctx = (QPSConvergedDefaultCtx*) ctx;
+  QPSConvergedDefaultCtx *cctx = (QPSConvergedDefaultCtx*) qps->cnvctx;
   PetscInt i = qps->iteration;
   PetscReal rnorm = qps->rnorm;
 
@@ -693,7 +693,7 @@ PetscErrorCode QPSConvergedDefault(QPS qps,KSPConvergedReason *reason,void *ctx)
 
   if (!cctx) FLLOP_SETERRQ(((PetscObject) qps)->comm, PETSC_ERR_ARG_NULL, "Convergence context must have been created with QPSConvergedDefaultCreate()");
   if (!cctx->setup_called) {
-    TRY( QPSConvergedDefaultSetUp(ctx,qps) );
+    TRY( QPSConvergedDefaultSetUp(qps) );
   }
 
   if (i > qps->max_it) {
@@ -724,9 +724,9 @@ PetscErrorCode QPSConvergedDefault(QPS qps,KSPConvergedReason *reason,void *ctx)
 
 #undef __FUNCT__
 #define __FUNCT__ "QPSConvergedDefaultSetUp"
-PetscErrorCode QPSConvergedDefaultSetUp(void *ctx, QPS qps)
+PetscErrorCode QPSConvergedDefaultSetUp(QPS qps)
 {
-  QPSConvergedDefaultCtx *cctx = (QPSConvergedDefaultCtx*) ctx;
+  QPSConvergedDefaultCtx *cctx = (QPSConvergedDefaultCtx*) qps->cnvctx;
 
   PetscFunctionBegin;
   if (cctx->setup_called) PetscFunctionReturn(0);
@@ -779,7 +779,7 @@ PetscErrorCode QPSConvergedDefaultCreate(void **ctx)
 
 #undef __FUNCT__  
 #define __FUNCT__ "QPSConvergedSkip"
-PetscErrorCode QPSConvergedSkip(QPS qps,KSPConvergedReason *reason,void *ctx)
+PetscErrorCode QPSConvergedSkip(QPS qps,KSPConvergedReason *reason)
 {
   PetscFunctionBegin;
   PetscValidHeaderSpecific(qps,QPS_CLASSID,1);


### PR DESCRIPTION
Solved QP, iteration and residual norm are available from the QPS struct.