### PR TITLE
fix MatTimer uninitialized variable

### DIFF
--- a/src/mat/impls/timer/mattimer.c
+++ b/src/mat/impls/timer/mattimer.c
@@ -63,7 +63,22 @@ PetscErrorCode MatDestroy_Timer(Mat W) {
 
 #undef __FUNCT__
 #define __FUNCT__ "MatCreateTimer"
-PetscErrorCode MatCreateTimer(Mat A, Mat *W_inout) {
+/*@
+   MatCreateTimer - Creates a matrix that behaves like original but logs all MatMult operations
+
+   Collective
+
+   Input Parameters:
+.  A - original matrix
+
+   Output Parameters:
+.  B - matrix A that logs MatMult operations 
+
+   Level: developer
+
+.seealso MatTimerSetOperation(), MatTimerGetMat()
+@*/
+PetscErrorCode MatCreateTimer(Mat A, Mat *B) {
     Mat_Timer *ctx;
     Mat W;
     
@@ -81,7 +96,7 @@ PetscErrorCode MatCreateTimer(Mat A, Mat *W_inout) {
     TRY( MatTimerSetOperation(W,MATOP_MULT_TRANSPOSE,"MatMultTr",(void(*)(void))MatMultTranspose_Timer) );
     TRY( MatTimerSetOperation(W,MATOP_MULT_TRANSPOSE_ADD,"MatMultTrAdd",(void(*)(void))MatMultTransposeAdd_Timer) );
     
-    *W_inout = W;
+    *B = W;
     PetscFunctionReturn(0);
 }
 

--- a/src/mat/impls/timer/mattimer.c
+++ b/src/mat/impls/timer/mattimer.c
@@ -81,10 +81,6 @@ PetscErrorCode MatCreateTimer(Mat A, Mat *W_inout) {
     TRY( MatTimerSetOperation(W,MATOP_MULT_TRANSPOSE,"MatMultTr",(void(*)(void))MatMultTranspose_Timer) );
     TRY( MatTimerSetOperation(W,MATOP_MULT_TRANSPOSE_ADD,"MatMultTrAdd",(void(*)(void))MatMultTransposeAdd_Timer) );
     
-    if (*W_inout == A) {
-      /* the original object will be replaced by the wrapper */
-      TRY( MatDestroy(W_inout) );
-    }
     *W_inout = W;
     PetscFunctionReturn(0);
 }

--- a/src/qppf/interface/qppf.c
+++ b/src/qppf/interface/qppf.c
@@ -247,14 +247,16 @@ static PetscErrorCode QPPFSetUpGGt_Private(QPPF cp, Mat *newGGt)
     //TODO if GGt fill > 0.3, use PETSC_FALSE (dense result)
     TRY( PermonMatMatMult(cp->G,cp->Gt,MAT_INITIAL_MATRIX,cp->GGt_relative_fill,&GGt) );
   } else {
-    Mat GGt_arr[2];
+    Mat GGt_arr[3];
 
     TRY( MatCreateTimer(cp->G,&GGt_arr[1]) );
     TRY( MatCreateTimer(cp->Gt,&GGt_arr[0]) );
 
     TRY( MatCreateProd(comm, 2, GGt_arr, &GGt) );
     TRY( PetscObjectSetName((PetscObject)GGt,"GGt") );
-    TRY( MatCreateTimer(GGt,&GGt) );
+    TRY( MatCreateTimer(GGt,&GGt_arr[2]) );
+    TRY( MatDestroy(&GGt) );
+    GGt = GGt_arr[2];
 
     TRY( PetscObjectCompose((PetscObject)GGt,"Gt",(PetscObject)cp->Gt) );
     TRY( PetscObjectCompose((PetscObject)GGt,"G",(PetscObject)cp->G) );


### PR DESCRIPTION
Resolves #25 by removing the in-place creation so that the behaviour is consistent with other MatCreate functions like MatCreateTranspose.