### PR TITLE
matinv fixes

### DIFF
--- a/src/mat/impls/inv/matinv.c
+++ b/src/mat/impls/inv/matinv.c
@@ -143,6 +143,8 @@ static PetscErrorCode MatInvComputeNullSpace_Inv(Mat imat)
     } else mumps->id.rhs = array;
     /* mumps->id.nrhs is reset by MatMatSolve_MUMPS()/MatSolve_MUMPS() */
     mumps->id.nrhs = defect;
+    mumps->id.lrhs = (mumps->petsc_size > 1) ? M : mm;
+    mumps->id.lrhs_loc = mm;
     TRY( MatMumpsSetIcntl(F,25,-1) ); /* compute complete null space */
     mumps->id.job = JOB_SOLVE;
     PetscMUMPS_c(&mumps->id);

--- a/src/mat/interface/permonmatregularize.c
+++ b/src/mat/interface/permonmatregularize.c
@@ -130,7 +130,7 @@ static PetscErrorCode MatRegularize_GetRegularization_Private(Mat K_loc, Mat R_l
   TRY( ISGetSize(pivots, &npivots) );
 
   if (npivots) {
-    Mat RI, RIt, RItRI, invRItRI, RI_invRItRI, Q_loc_condensed_filtered;
+    Mat RI, RIt, RItRI, iRItRI, invRItRI, RI_invRItRI, Q_loc_condensed_filtered;
     IS R_all_cols;
 
     /* R_all_cols = 0:1:defect_loc-1 */
@@ -144,9 +144,9 @@ static PetscErrorCode MatRegularize_GetRegularization_Private(Mat K_loc, Mat R_l
     TRY( MatMatMult(RIt, RI, MAT_INITIAL_MATRIX, 1.0, &RItRI) );
   
     TRY( MatCreateInv(RItRI, MAT_INV_MONOLITHIC, &invRItRI) );
-    TRY( MatInvExplicitly(invRItRI, PETSC_FALSE, MAT_REUSE_MATRIX, &RItRI) );
+    TRY( MatInvExplicitly(invRItRI, PETSC_FALSE, MAT_INITIAL_MATRIX, &iRItRI) );
     TRY( MatDestroy(&invRItRI) );
-    invRItRI = RItRI;
+    invRItRI = iRItRI;
 
     TRY( MatMatMult(RI, invRItRI, MAT_INITIAL_MATRIX, 1.0, &RI_invRItRI) );
     TRY( MatMatMult(RI_invRItRI, RIt, MAT_INITIAL_MATRIX, 1.0, &Q_loc_condensed) );

--- a/src/tutorials/feti/ex71.c
+++ b/src/tutorials/feti/ex71.c
@@ -410,9 +410,9 @@ int main(int argc,char **args)
     test:
       nsize: 6
       suffix: 1
-      args: -pde_type Poisson -dim 3 -feti_gluing_type {{nonred full orth}separate output}
+      args: -pde_type Poisson -cells 7,8,9 -dim 3 -feti_gluing_type {{nonred full orth}separate output}
     test:
       nsize: 7
       suffix: 2
-      args: -pde_type Elasticity -cells 7,8,9 -dim 3 -qps_rtol 1e-6 -dual_pc_dual_type {{none lumped}separate output}
+      args: -pde_type Elasticity -dim 3 -qps_rtol 1e-6 -dual_pc_dual_type {{none lumped}separate output}
  TEST*/

--- a/src/tutorials/feti/output/ex71_1_feti_gluing_type-full.out
+++ b/src/tutorials/feti/output/ex71_1_feti_gluing_type-full.out
@@ -1,13 +1,8 @@
-  last QPSSolve CONVERGED due to CONVERGED_RTOL, KSPReason=2, required 8 iterations
-r = ||A*x - b|| = 3.02e-04    rO/||b|| = 7.03e-06
-r = ||A*x - b + (B'*lambda)|| = 0.00e+00    rO/||b|| = 0.00e+00
-r = ||BE*x||             = 6.13e-13    r/||b|| = 3.28e-15
-r = ||A*x - b + (B'*lambda)|| = 4.55e-14    rO/||b|| = 3.05e-15
-r = ||BE*x-cE||          = 6.48e-13    r/||b|| = 4.35e-14
-r = ||A*x - b + (B'*lambda)|| = 4.55e-14    rO/||b|| = 3.05e-15
-r = ||BE*x-cE||          = 6.48e-13    r/||b|| = 4.35e-14
-r = ||A*x - b + B'*lambda|| = 7.70e-13    rO/||b|| = 4.78e-14
-r = ||BE*x||             = 3.02e-04    r/||b|| = 1.87e-05
-r = ||A*x - b + B'*lambda|| = 7.70e-13    rO/||b|| = 4.78e-14
-r = ||BE*x||             = 3.02e-04    r/||b|| = 1.87e-05
-r = ||A*x - b|| = 2.39e-04    rO/||b|| = 1.35e-05
+  last QPSSolve CONVERGED due to CONVERGED_RTOL, KSPReason=2, required 9 iterations
+r = ||A*x - b|| = 1.41e-04    rO/||b|| = 4.59e-06
+r = ||A*x - b|| = 1.41e-04    rO/||b|| = 4.59e-06
+r = ||A*x - b + B'*lambda|| = 3.00e-13    rO/||b|| = 1.21e-14
+r = ||BE*x||             = 1.41e-04    r/||b|| = 5.71e-06
+r = ||A*x - b + B'*lambda|| = 3.00e-13    rO/||b|| = 1.21e-14
+r = ||BE*x||             = 1.41e-04    r/||b|| = 5.71e-06
+r = ||A*x - b|| = 2.50e-04    rO/||b|| = 9.31e-06

--- a/src/tutorials/feti/output/ex71_1_feti_gluing_type-nonred.out
+++ b/src/tutorials/feti/output/ex71_1_feti_gluing_type-nonred.out
@@ -1,13 +1,8 @@
-  last QPSSolve CONVERGED due to CONVERGED_RTOL, KSPReason=2, required 15 iterations
-r = ||A*x - b|| = 2.95e-04    rO/||b|| = 5.85e-06
-r = ||A*x - b + (B'*lambda)|| = 0.00e+00    rO/||b|| = 0.00e+00
-r = ||BE*x||             = 7.17e-13    r/||b|| = 3.92e-15
-r = ||A*x - b + (B'*lambda)|| = 3.93e-14    rO/||b|| = 2.87e-15
-r = ||BE*x-cE||          = 7.30e-13    r/||b|| = 5.34e-14
-r = ||A*x - b + (B'*lambda)|| = 3.93e-14    rO/||b|| = 2.87e-15
-r = ||BE*x-cE||          = 7.30e-13    r/||b|| = 5.34e-14
-r = ||A*x - b + B'*lambda|| = 8.41e-13    rO/||b|| = 5.22e-14
-r = ||BE*x||             = 2.95e-04    r/||b|| = 1.83e-05
-r = ||A*x - b + B'*lambda|| = 8.41e-13    rO/||b|| = 5.22e-14
-r = ||BE*x||             = 2.95e-04    r/||b|| = 1.83e-05
-r = ||A*x - b|| = 4.24e-04    rO/||b|| = 2.39e-05
+  last QPSSolve CONVERGED due to CONVERGED_RTOL, KSPReason=2, required 16 iterations
+r = ||A*x - b|| = 1.73e-04    rO/||b|| = 5.93e-06
+r = ||A*x - b|| = 1.73e-04    rO/||b|| = 5.93e-06
+r = ||A*x - b + B'*lambda|| = 3.10e-13    rO/||b|| = 1.25e-14
+r = ||BE*x||             = 1.73e-04    r/||b|| = 7.01e-06
+r = ||A*x - b + B'*lambda|| = 3.10e-13    rO/||b|| = 1.25e-14
+r = ||BE*x||             = 1.73e-04    r/||b|| = 7.01e-06
+r = ||A*x - b|| = 4.11e-04    rO/||b|| = 1.53e-05

--- a/src/tutorials/feti/output/ex71_1_feti_gluing_type-orth.out
+++ b/src/tutorials/feti/output/ex71_1_feti_gluing_type-orth.out
@@ -1,13 +1,8 @@
-  last QPSSolve CONVERGED due to CONVERGED_RTOL, KSPReason=2, required 8 iterations
-r = ||A*x - b|| = 3.02e-04    rO/||b|| = 7.03e-06
-r = ||A*x - b + (B'*lambda)|| = 1.78e-15    rO/||b|| = 9.50e-18
-r = ||BE*x||             = 5.23e-13    r/||b|| = 2.80e-15
-r = ||A*x - b + (B'*lambda)|| = 3.44e-14    rO/||b|| = 2.31e-15
-r = ||BE*x-cE||          = 5.55e-13    r/||b|| = 3.72e-14
-r = ||A*x - b + (B'*lambda)|| = 3.40e-14    rO/||b|| = 2.28e-15
-r = ||BE*x-cE||          = 5.55e-13    r/||b|| = 3.72e-14
-r = ||A*x - b + B'*lambda|| = 6.90e-13    rO/||b|| = 4.28e-14
-r = ||BE*x||             = 3.02e-04    r/||b|| = 1.87e-05
-r = ||A*x - b + B'*lambda|| = 6.90e-13    rO/||b|| = 4.28e-14
-r = ||BE*x||             = 3.02e-04    r/||b|| = 1.87e-05
-r = ||A*x - b|| = 2.39e-04    rO/||b|| = 1.35e-05
+  last QPSSolve CONVERGED due to CONVERGED_RTOL, KSPReason=2, required 9 iterations
+r = ||A*x - b|| = 1.41e-04    rO/||b|| = 4.59e-06
+r = ||A*x - b|| = 1.41e-04    rO/||b|| = 4.59e-06
+r = ||A*x - b + B'*lambda|| = 3.11e-13    rO/||b|| = 1.26e-14
+r = ||BE*x||             = 1.41e-04    r/||b|| = 5.71e-06
+r = ||A*x - b + B'*lambda|| = 3.11e-13    rO/||b|| = 1.26e-14
+r = ||BE*x||             = 1.41e-04    r/||b|| = 5.71e-06
+r = ||A*x - b|| = 2.50e-04    rO/||b|| = 9.31e-06

--- a/src/tutorials/feti/output/ex71_2_dual_pc_dual_type-lumped.out
+++ b/src/tutorials/feti/output/ex71_2_dual_pc_dual_type-lumped.out
@@ -1,11 +1,13 @@
-  last QPSSolve CONVERGED due to CONVERGED_RTOL, KSPReason=2, required 72 iterations
-r = ||A*x - b|| = 4.36e-03    rO/||b|| = 6.69e-07
+  last QPSSolve CONVERGED due to CONVERGED_RTOL, KSPReason=2, required 27 iterations
+r = ||A*x - b|| = 1.31e-04    rO/||b|| = 6.42e-07
 r = ||A*x - b + (B'*lambda)|| = 0.00e+00    rO/||b|| = 0.00e+00
-r = ||BE*x||             = 0.00e+00    r/||b|| = 0.00e+00
-r = ||A*x - b + (B'*lambda)|| = 0.00e+00    rO/||b|| = 0.00e+00
-r = ||BE*x||             = 0.00e+00    r/||b|| = 0.00e+00
-r = ||A*x - b + B'*lambda|| = 1.50e-12    rO/||b|| = 3.85e-14
-r = ||BE*x||             = 4.36e-03    r/||b|| = 1.12e-04
-r = ||A*x - b + B'*lambda|| = 1.50e-12    rO/||b|| = 3.85e-14
-r = ||BE*x||             = 4.36e-03    r/||b|| = 1.12e-04
-r = ||A*x - b|| = 1.17e-02    rO/||b|| = 2.53e-04
+r = ||BE*x||             = 4.40e-13    r/||b|| = 8.51e-16
+r = ||A*x - b + (B'*lambda)|| = 1.41e-11    rO/||b|| = 1.11e-12
+r = ||BE*x-cE||          = 1.40e-12    r/||b|| = 1.10e-13
+r = ||A*x - b + (B'*lambda)|| = 1.41e-11    rO/||b|| = 1.11e-12
+r = ||BE*x-cE||          = 1.40e-12    r/||b|| = 1.10e-13
+r = ||A*x - b + B'*lambda|| = 1.30e-11    rO/||b|| = 5.19e-13
+r = ||BE*x||             = 1.31e-04    r/||b|| = 5.22e-06
+r = ||A*x - b + B'*lambda|| = 1.30e-11    rO/||b|| = 5.19e-13
+r = ||BE*x||             = 1.31e-04    r/||b|| = 5.22e-06
+r = ||A*x - b|| = 4.53e-04    rO/||b|| = 1.47e-05

--- a/src/tutorials/feti/output/ex71_2_dual_pc_dual_type-none.out
+++ b/src/tutorials/feti/output/ex71_2_dual_pc_dual_type-none.out
@@ -1,11 +1,13 @@
-  last QPSSolve CONVERGED due to CONVERGED_RTOL, KSPReason=2, required 117 iterations
-r = ||A*x - b|| = 3.99e-03    rO/||b|| = 6.13e-07
+  last QPSSolve CONVERGED due to CONVERGED_RTOL, KSPReason=2, required 66 iterations
+r = ||A*x - b|| = 1.49e-04    rO/||b|| = 7.28e-07
 r = ||A*x - b + (B'*lambda)|| = 0.00e+00    rO/||b|| = 0.00e+00
-r = ||BE*x||             = 0.00e+00    r/||b|| = 0.00e+00
-r = ||A*x - b + (B'*lambda)|| = 0.00e+00    rO/||b|| = 0.00e+00
-r = ||BE*x||             = 0.00e+00    r/||b|| = 0.00e+00
-r = ||A*x - b + B'*lambda|| = 1.50e-12    rO/||b|| = 3.85e-14
-r = ||BE*x||             = 3.99e-03    r/||b|| = 1.03e-04
-r = ||A*x - b + B'*lambda|| = 1.50e-12    rO/||b|| = 3.85e-14
-r = ||BE*x||             = 3.99e-03    r/||b|| = 1.03e-04
-r = ||A*x - b|| = 1.46e-02    rO/||b|| = 3.14e-04
+r = ||BE*x||             = 4.80e-11    r/||b|| = 9.28e-14
+r = ||A*x - b + (B'*lambda)|| = 1.65e-11    rO/||b|| = 1.30e-12
+r = ||BE*x-cE||          = 4.98e-11    r/||b|| = 3.93e-12
+r = ||A*x - b + (B'*lambda)|| = 1.65e-11    rO/||b|| = 1.30e-12
+r = ||BE*x-cE||          = 4.98e-11    r/||b|| = 3.93e-12
+r = ||A*x - b + B'*lambda|| = 5.15e-11    rO/||b|| = 2.05e-12
+r = ||BE*x||             = 1.49e-04    r/||b|| = 5.92e-06
+r = ||A*x - b + B'*lambda|| = 5.15e-11    rO/||b|| = 2.05e-12
+r = ||BE*x||             = 1.49e-04    r/||b|| = 5.92e-06
+r = ||A*x - b|| = 3.63e-04    rO/||b|| = 1.18e-05


### PR DESCRIPTION
contains fixes for matinv needed for ex71 and permoncube
- fix mumps lrhs size missing
- create a new matrix for explicit inversion in matreg
- update ex71 outputs