### PR TITLE
fix complex build

### DIFF
--- a/include/permon/private/qpcimpl.h
+++ b/include/permon/private/qpcimpl.h
@@ -19,7 +19,7 @@ struct _QPCOps {
   PetscErrorCode (*getconstraintfunction)(QPC, Vec, Vec *);
   PetscErrorCode (*restoreconstraintfunction)(QPC, Vec, Vec *);
   PetscErrorCode (*project)(QPC, Vec, Vec);
-  PetscErrorCode (*feas)(QPC, Vec, Vec, PetscScalar *);
+  PetscErrorCode (*feas)(QPC, Vec, Vec, PetscReal *);
   PetscErrorCode (*grads)(QPC, Vec, Vec, Vec, Vec);
   PetscErrorCode (*gradreduced)(QPC, Vec, Vec, PetscReal, Vec);
 };

--- a/include/permonmat.h
+++ b/include/permonmat.h
@@ -129,7 +129,7 @@ PERMON_EXTERN PetscErrorCode MatHasOrthonormalRowsImplicitly(Mat A, PetscBool *f
 PERMON_EXTERN PetscErrorCode MatIsZero(Mat A, PetscReal tol, PetscInt ntrials, PetscBool *flg);
 PERMON_EXTERN PetscErrorCode MatMatIsZero(Mat A, Mat B, PetscReal tol, PetscInt ntrials, PetscBool *flg);
 PERMON_EXTERN PetscErrorCode MatIsSymmetricByType(Mat A, PetscBool *flg);
-PERMON_EXTERN PetscErrorCode MatGetMaxEigenvalue(Mat A, Vec v, PetscScalar *lambda_out, PetscReal tol, PetscInt maxits);
+PERMON_EXTERN PetscErrorCode MatGetMaxEigenvalue(Mat A, Vec v, PetscReal *lambda_out, PetscReal tol, PetscInt maxits);
 PERMON_EXTERN PetscErrorCode MatGetColumnVectors(Mat A, PetscInt *ncols, Vec *cols_new[]);
 PERMON_EXTERN PetscErrorCode MatRestoreColumnVectors(Mat A, PetscInt *ncols, Vec *cols_new[]);
 PERMON_EXTERN PetscErrorCode MatFilterZeros(Mat A, PetscReal tol, Mat *Af);

--- a/include/permonqpc.h
+++ b/include/permonqpc.h
@@ -46,7 +46,7 @@ PERMON_EXTERN PetscErrorCode QPCGetNumberOfConstraints(QPC, PetscInt *num);
 PERMON_EXTERN PetscErrorCode QPCProject(QPC, Vec x, Vec Px);
 PERMON_EXTERN PetscErrorCode QPCGrads(QPC, Vec x, Vec g, Vec gf, Vec gc);
 PERMON_EXTERN PetscErrorCode QPCGradReduced(QPC qpc, Vec x, Vec gf, PetscReal alpha, Vec gr);
-PERMON_EXTERN PetscErrorCode QPCFeas(QPC, Vec x, Vec d, PetscScalar *alpha);
+PERMON_EXTERN PetscErrorCode QPCFeas(QPC, Vec x, Vec d, PetscReal *alpha);
 PERMON_EXTERN PetscErrorCode QPCOuterNormal(QPC, PetscScalar *n_a, PetscScalar *xconstr_a, PetscInt local_idx);
 
 /* BOX */

--- a/src/mat/impls/inv/matinv.c
+++ b/src/mat/impls/inv/matinv.c
@@ -126,17 +126,17 @@ static PetscErrorCode MatInvComputeNullSpace_Inv(Mat imat)
   if (defect) {
     /* stash sol_loc allocated in MatFactorNumeric_MUMPS() */
     MumpsScalar *sol_loc_orig = mumps->id.sol_loc;
-    MumpsScalar *array;
+    PetscScalar *array;
 
     /* inject matrix array as sol_loc */
-    PetscCall(MatDenseGetArray(Rl, (MumpsScalar **)&array));
+    PetscCall(MatDenseGetArray(Rl, &array));
     if (mumps->petsc_size > 1) {
-      mumps->id.sol_loc = array;
+      mumps->id.sol_loc = (MumpsScalar *)array;
       if (!mumps->myid) {
         /* Define dummy rhs on the host otherwise MUMPS fails with INFOG(1)=-22,INFOG(2)=7 */
         PetscCall(PetscMalloc1(M, &mumps->id.rhs));
       }
-    } else mumps->id.rhs = array;
+    } else mumps->id.rhs = (MumpsScalar *)array;
     /* mumps->id.nrhs is reset by MatMatSolve_MUMPS()/MatSolve_MUMPS() */
     mumps->id.nrhs     = defect;
     mumps->id.lrhs     = (mumps->petsc_size > 1) ? M : mm;
@@ -150,7 +150,7 @@ static PetscErrorCode MatInvComputeNullSpace_Inv(Mat imat)
     PetscCall(MatMumpsSetIcntl(F, 25, 0)); /* perform a normal solution step next time */
 
     /* restore matrix array */
-    PetscCall(MatDenseRestoreArray(Rl, (MumpsScalar **)&array));
+    PetscCall(MatDenseRestoreArray(Rl, &array));
     /* restore stashed sol_loc */
     mumps->id.sol_loc = sol_loc_orig;
   }

--- a/src/mat/interface/permonmatregularize.c
+++ b/src/mat/interface/permonmatregularize.c
@@ -203,7 +203,7 @@ PetscErrorCode MatRegularize(Mat K, Mat R, MatRegularizationType type, Mat *newK
   MPI_Comm              comm;
   IS                    pivots;
   Mat                   Q_loc, Kreg;
-  PetscScalar           rho;
+  PetscReal             rho;
   Mat                   K_loc, R_loc;
   PETSC_UNUSED PetscInt regularized_int;
   PetscBool             regularized = PETSC_FALSE;

--- a/src/mat/interface/permonmatutils.c
+++ b/src/mat/interface/permonmatutils.c
@@ -439,15 +439,15 @@ PetscErrorCode MatMatIsZero(Mat A, Mat B, PetscReal tol, PetscInt ntrials, Petsc
 
    Level: intermediate
 @*/
-PetscErrorCode MatGetMaxEigenvalue(Mat A, Vec v, PetscScalar *lambda_out, PetscReal tol, PetscInt maxits)
+PetscErrorCode MatGetMaxEigenvalue(Mat A, Vec v, PetscReal *lambda_out, PetscReal tol, PetscInt maxits)
 {
   static PetscBool registered = PETSC_FALSE;
   Vec              Av;
   PetscInt         i;
-  PetscScalar      lambda, lambda0;
+  PetscReal        lambda, lambda0;
   PetscReal        err, relerr;
   Vec              y_v[2];
-  PetscReal        vAv_vv[2];
+  PetscScalar      vAv_vv[2];
   PetscBool        destroy_v = PETSC_FALSE;
   PetscBool        flg;
   PetscRandom      rand = NULL;
@@ -489,7 +489,7 @@ PetscErrorCode MatGetMaxEigenvalue(Mat A, Vec v, PetscScalar *lambda_out, PetscR
     //PetscCall(VecDot(v, y, &vAv));
     //PetscCall(VecDot(v, v, &vv));
     PetscCall(VecMDot(v, 2, y_v, vAv_vv));
-    lambda = vAv_vv[0] / vAv_vv[1];
+    lambda = PetscRealPart(vAv_vv[0] / vAv_vv[1]);
     if (lambda < PETSC_MACHINE_EPSILON) {
       PetscCall(PetscInfo(permon, "hit nullspace of A and setting A*v to random vector in iteration %" PetscInt_FMT "\n", i));
 
@@ -501,8 +501,8 @@ PetscErrorCode MatGetMaxEigenvalue(Mat A, Vec v, PetscScalar *lambda_out, PetscR
       PetscCall(VecDot(v, Av, &vAv_vv[0]));
     }
 
-    err    = PetscAbsScalar(lambda - lambda0);
-    relerr = err / PetscAbsScalar(lambda);
+    err    = PetscAbs(lambda - lambda0);
+    relerr = err / PetscAbs(lambda);
     if (relerr < tol) break;
 
     /* v = A*v/||A*v||  replaced by v = A*v/||v|| */
@@ -547,7 +547,7 @@ static PetscErrorCode MatFilterZeros_Default(Mat A, PetscReal tol, Mat *newAf)
     d_nnz[i] = 0;
     o_nnz[i] = 0;
     for (j = 0; j < ncols; j++) {
-      if (PetscAbs(vals[j]) > tol) {
+      if (PetscAbsScalar(vals[j]) > tol) {
         if (cols[j] >= jlo && cols[j] < jhi) d_nnz[i]++;
         else o_nnz[i]++;
       }
@@ -570,7 +570,7 @@ static PetscErrorCode MatFilterZeros_Default(Mat A, PetscReal tol, Mat *newAf)
     PetscCall(MatGetRow(A, i, &ncols, &cols, &vals));
     jf = 0;
     for (j = 0; j < ncols; j++) {
-      if (PetscAbs(vals[j]) > tol) {
+      if (PetscAbsScalar(vals[j]) > tol) {
         valsf[jf] = vals[j];
         colsf[jf] = cols[j];
         jf++;

--- a/src/mat/utils/permonmatfetiutils.c
+++ b/src/mat/utils/permonmatfetiutils.c
@@ -112,14 +112,14 @@ PetscErrorCode MatRemoveGluingOfDirichletDofs(Mat Bgt, Vec cg, Mat Bdt, Mat *Bgt
       PetscCall(MatGetRow(Bdt, i, &ncolsd, &colsd, &valsd));
       k = 0;
       for (jj = 0; jj < ncolsd; jj++) {
-        if (valsd[jj] > PETSC_MACHINE_EPSILON) k++;
+        if (PetscRealPart(valsd[jj]) > PETSC_MACHINE_EPSILON) k++;
         PetscCheck(k <= 1, comm, PETSC_ERR_PLIB, "more than one nonzero in Bd row %" PetscInt_FMT "", i);
       }
       PetscCall(MatRestoreRow(Bdt, i, &ncolsd, &colsd, &valsd));
       if (k) {
         PetscCall(MatGetRow(Bgt, i, &ncolsg, &colsg, &valsg));
         for (jj = 0; jj < ncolsg; jj++) {
-          if (valsg[jj] > PETSC_MACHINE_EPSILON) {
+          if (PetscRealPart(valsg[jj]) > PETSC_MACHINE_EPSILON) {
             j = colsg[jj];
             if (j >= jlog && j < jhig) remove[j - jlog] = PETSC_TRUE;
           }

--- a/src/qp/impls/feti/qpfeti.c
+++ b/src/qp/impls/feti/qpfeti.c
@@ -291,8 +291,8 @@ PetscErrorCode QPFetiAssembleDirichlet(QP qp)
       }
     }
   } else {
-    Vec         d;
-    PetscScalar alpha;
+    Vec       d;
+    PetscReal alpha;
 
     /* alpha=max(abs(diag(A)) */
     PetscCall(MatCreateVecs(qp->A, NULL, &d));

--- a/src/qp/interface/qp.c
+++ b/src/qp/interface/qp.c
@@ -244,12 +244,13 @@ PetscErrorCode QPCompareEqMultiplierWithLeastSquare(QP qp, PetscReal *norm)
 @*/
 PetscErrorCode QPViewKKT(QP qp, PetscViewer v)
 {
-  PetscReal normb = 0.0, norm = 0.0, dot = 0.0;
-  Vec       x, b, cE, cI, r, o, t;
-  Mat       A, BE, BI;
-  PetscBool flg = PETSC_FALSE, compare_lambda_E = PETSC_FALSE, notavail;
-  MPI_Comm  comm;
-  char     *kkt_name;
+  PetscReal   normb = 0.0, norm = 0.0;
+  PetscScalar dot = 0.0;
+  Vec         x, b, cE, cI, r, o, t;
+  Mat         A, BE, BI;
+  PetscBool   flg = PETSC_FALSE, compare_lambda_E = PETSC_FALSE, notavail;
+  MPI_Comm    comm;
+  char       *kkt_name;
 
   PetscFunctionBegin;
   PetscValidHeaderSpecific(qp, QP_CLASSID, 1);
@@ -317,8 +318,8 @@ PetscErrorCode QPViewKKT(QP qp, PetscViewer v)
       } else {
         Vec t = qp->xwork;
         PetscCall(QPPFApplyGtG(qp->pf, x, t)); /* BEtBEx = BE'*BE*x */
-        PetscCall(VecDot(x, t, &norm));        /* norm = x'*BE'*BE*x */
-        norm = PetscSqrtReal(norm);
+        PetscCall(VecDot(x, t, &dot));         /* norm = x'*BE'*BE*x */
+        norm = PetscSqrtReal(dot);
         PetscCall(PetscViewerASCIIPrintf(v, "r = ||BE*x||             = %.2e    r/||b|| = %.2e\n", (double)norm, (double)norm / (double)normb));
       }
     }
@@ -352,7 +353,7 @@ PetscErrorCode QPViewKKT(QP qp, PetscViewer v)
 
     /* lambda'*(BI*x-cI) = 0 */
     PetscCall(VecDot(qp->lambda_I, r, &dot));
-    dot = PetscAbs(dot);
+    dot = PetscAbsScalar(dot);
     if (cI) {
       PetscCall(PetscViewerASCIIPrintf(v, "r = |lambda_I'*(BI*x-cI)|= %.2e    r/||b|| = %.2e\n", (double)dot, (double)dot / (double)normb));
     } else {
@@ -911,6 +912,8 @@ PetscErrorCode QPComputeMissingBoxMultipliers(QP qp)
 @*/
 PetscErrorCode QPComputeObjective(QP qp, Vec x, PetscReal *f)
 {
+  PetscScalar dot;
+
   PetscFunctionBegin;
   PetscValidHeaderSpecific(qp, QP_CLASSID, 1);
   PetscValidHeaderSpecific(x, VEC_CLASSID, 2);
@@ -918,8 +921,8 @@ PetscErrorCode QPComputeObjective(QP qp, Vec x, PetscReal *f)
   PetscCheck(qp->setupcalled, PetscObjectComm((PetscObject)qp), PETSC_ERR_ORDER, "QPSetUp must be called first.");
   PetscCall(MatMult(qp->A, x, qp->xwork));
   PetscCall(VecAYPX(qp->xwork, -0.5, qp->b));
-  PetscCall(VecDot(x, qp->xwork, f));
-  *f = -*f;
+  PetscCall(VecDot(x, qp->xwork, &dot));
+  *f = -dot;
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
@@ -977,6 +980,8 @@ PetscErrorCode QPComputeObjectiveGradient(QP qp, Vec x, Vec g)
 @*/
 PetscErrorCode QPComputeObjectiveFromGradient(QP qp, Vec x, Vec g, PetscReal *f)
 {
+  PetscScalar dot;
+
   PetscFunctionBegin;
   PetscValidHeaderSpecific(qp, QP_CLASSID, 1);
   PetscValidHeaderSpecific(x, VEC_CLASSID, 2);
@@ -985,8 +990,8 @@ PetscErrorCode QPComputeObjectiveFromGradient(QP qp, Vec x, Vec g, PetscReal *f)
   PetscCheck(qp->setupcalled, PetscObjectComm((PetscObject)qp), PETSC_ERR_ORDER, "QPSetUp must be called first.");
 
   PetscCall(VecWAXPY(qp->xwork, -1.0, qp->b, g));
-  PetscCall(VecDot(x, qp->xwork, f));
-  *f /= 2.0;
+  PetscCall(VecDot(x, qp->xwork, &dot));
+  *f = .5 * dot;
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 

--- a/src/qpc/impls/box/qpcbox.c
+++ b/src/qpc/impls/box/qpcbox.c
@@ -42,12 +42,12 @@ static PetscErrorCode QPCGrads_Box(QPC qpc, Vec x, Vec g, Vec gf, Vec gc)
     if (lb && PetscAbsScalar(x_a[i] - lb_a[i]) <= qpc->astol) {
       /* active lower bound */
       gf_a[i] = 0.0;
-      gc_a[i] = PetscMin(g_a[i], 0.0);
+      gc_a[i] = PetscMin(PetscRealPart(g_a[i]), 0.0);
       //} else if (ub && x_a[i] >= ub_a[i]) {
     } else if (ub && PetscAbsScalar(x_a[i] - ub_a[i]) <= qpc->astol) {
       /* active upper bound */
       gf_a[i] = 0.0;
-      gc_a[i] = PetscMax(g_a[i], 0.0);
+      gc_a[i] = PetscMax(PetscRealPart(g_a[i]), 0.0);
     } else {
       /* index of this component is in FREE SET */
       gf_a[i] = g_a[i];
@@ -84,10 +84,10 @@ static PetscErrorCode QPCGradReduced_Box(QPC qpc, Vec x, Vec gf, PetscReal alpha
   PetscCall(VecGetArray(gr, &gr_a));
 
   for (i = 0; i < n_local; i++) {
-    if (lb && gf_a[i] > 0.0) {
-      gr_a[i] = PetscMin(gf_a[i], (x_a[i] - lb_a[i]) / alpha);
-    } else if (ub && gf_a[i] < 0.0) {
-      gr_a[i] = PetscMax(gf_a[i], (x_a[i] - ub_a[i]) / alpha);
+    if (lb && PetscRealPart(gf_a[i]) > 0.0) {
+      gr_a[i] = PetscMin(PetscRealPart(gf_a[i]), PetscRealPart(x_a[i] - lb_a[i]) / alpha);
+    } else if (ub && PetscRealPart(gf_a[i]) < 0.0) {
+      gr_a[i] = PetscMax(PetscRealPart(gf_a[i]), PetscRealPart(x_a[i] - ub_a[i]) / alpha);
     }
   }
 
@@ -101,11 +101,11 @@ static PetscErrorCode QPCGradReduced_Box(QPC qpc, Vec x, Vec gf, PetscReal alpha
 
 #undef __FUNCT__
 #define __FUNCT__ "QPCFeas_Box"
-static PetscErrorCode QPCFeas_Box(QPC qpc, Vec x, Vec d, PetscScalar *alpha)
+static PetscErrorCode QPCFeas_Box(QPC qpc, Vec x, Vec d, PetscReal *alpha)
 {
-  Vec         lb, ub;
-  QPC_Box    *ctx = (QPC_Box *)qpc->data;
-  PetscScalar alpha_temp, alpha_i;
+  Vec       lb, ub;
+  QPC_Box  *ctx = (QPC_Box *)qpc->data;
+  PetscReal alpha_temp, alpha_i;
 
   PetscScalar *x_a, *d_a, *lb_a, *ub_a;
   PetscInt     n_local, i;
@@ -123,15 +123,15 @@ static PetscErrorCode QPCFeas_Box(QPC qpc, Vec x, Vec d, PetscScalar *alpha)
   if (ub) PetscCall(VecGetArray(ub, &ub_a));
 
   for (i = 0; i < n_local; i++) {
-    if (d_a[i] > 0 && lb && lb_a[i] > PETSC_NINFINITY) {
-      alpha_i = x_a[i] - lb_a[i];
-      alpha_i = alpha_i / d_a[i];
+    if (PetscRealPart(d_a[i]) > 0. && lb && PetscRealPart(lb_a[i]) > PETSC_NINFINITY) {
+      alpha_i = PetscRealPart(x_a[i] - lb_a[i]);
+      alpha_i = alpha_i / PetscRealPart(d_a[i]);
       if (alpha_i < alpha_temp) { alpha_temp = alpha_i; }
     }
 
-    if (d_a[i] < 0 && ub && ub_a[i] < PETSC_INFINITY) {
-      alpha_i = (x_a[i] - ub_a[i]);
-      alpha_i = alpha_i / d_a[i];
+    if (PetscRealPart(d_a[i]) < 0. && ub && PetscRealPart(ub_a[i]) < PETSC_INFINITY) {
+      alpha_i = PetscRealPart(x_a[i] - ub_a[i]);
+      alpha_i = alpha_i / PetscRealPart(d_a[i]);
 
       if (alpha_i < alpha_temp) { alpha_temp = alpha_i; }
     }
@@ -370,12 +370,12 @@ PetscErrorCode QPCViewKKT_Box(QPC qpc, Vec x, PetscReal normb, PetscViewer v)
       PetscCall(VecGetArray(r, &rarr));
       PetscCall(VecGetArrayRead(lb, &larr));
       for (i = 0; i < n; i++)
-        if (larr[i] <= PETSC_NINFINITY) rarr[i] = -1.0;
+        if (PetscRealPart(larr[i]) <= PETSC_NINFINITY) rarr[i] = -1.0;
       PetscCall(VecRestoreArray(r, &rarr));
       PetscCall(VecRestoreArrayRead(lb, &larr));
     }
     PetscCall(VecDot(llb, r, &dot));
-    norm = PetscAbs(dot);
+    norm = PetscAbsScalar(dot);
     PetscCall(PetscViewerASCIIPrintf(v, "r = |lambda_lb'*(lb-x)|  = %.2e    r/||b|| = %.2e\n", (double)norm, (double)norm / (double)normb));
 
     PetscCall(VecDestroy(&o));
@@ -412,12 +412,12 @@ PetscErrorCode QPCViewKKT_Box(QPC qpc, Vec x, PetscReal normb, PetscViewer v)
       PetscCall(VecGetArray(r, &rarr));
       PetscCall(VecGetArrayRead(ub, &uarr));
       for (i = 0; i < n; i++)
-        if (uarr[i] >= PETSC_INFINITY) rarr[i] = 1.0;
+        if (PetscRealPart(uarr[i]) >= PETSC_INFINITY) rarr[i] = 1.0;
       PetscCall(VecRestoreArray(r, &rarr));
       PetscCall(VecRestoreArrayRead(ub, &uarr));
     }
     PetscCall(VecDot(lub, r, &dot));
-    norm = PetscAbs(dot);
+    norm = PetscAbsScalar(dot);
     PetscCall(PetscViewerASCIIPrintf(v, "r = |lambda_ub'*(x-ub)|  = %.2e    r/||b|| = %.2e\n", (double)norm, (double)norm / normb));
 
     PetscCall(VecDestroy(&o));

--- a/src/qpc/interface/qpc.c
+++ b/src/qpc/interface/qpc.c
@@ -500,10 +500,10 @@ Parameters:
 . d - minus value of direction
 - alpha - pointer to return value
 @*/
-PetscErrorCode QPCFeas(QPC qpc, Vec x, Vec d, PetscScalar *alpha)
+PetscErrorCode QPCFeas(QPC qpc, Vec x, Vec d, PetscReal *alpha)
 {
-  Vec         x_sub, d_sub;
-  PetscScalar alpha_temp;
+  Vec       x_sub, d_sub;
+  PetscReal alpha_temp;
 
   PetscFunctionBegin;
   PetscValidHeaderSpecific(qpc, QPC_CLASSID, 1);
@@ -518,7 +518,7 @@ PetscErrorCode QPCFeas(QPC qpc, Vec x, Vec d, PetscScalar *alpha)
 
   /* compute largest step-size for the given QPC type */
   PetscUseTypeMethod(qpc, feas, x_sub, d_sub, &alpha_temp);
-  PetscCallMPI(MPI_Allreduce(&alpha_temp, alpha, 1, MPIU_SCALAR, MPIU_MIN, PetscObjectComm((PetscObject)qpc)));
+  PetscCallMPI(MPI_Allreduce(&alpha_temp, alpha, 1, MPIU_REAL, MPIU_MIN, PetscObjectComm((PetscObject)qpc)));
 
   /* restore the gradients */
   PetscCall(QPCRestoreSubvector(qpc, x, &x_sub));

--- a/src/qps/impls/mpgp/mpgp.c
+++ b/src/qps/impls/mpgp/mpgp.c
@@ -232,11 +232,11 @@ Parameters:
 */
 static PetscErrorCode MPGPExpansionLength(QPS qps)
 {
-  QP        qp;
-  Mat       A;
-  Vec       x, vecs[2];
-  PetscReal dots[2];
-  QPS_MPGP *mpgp = (QPS_MPGP *)qps->data;
+  QP          qp;
+  Mat         A;
+  Vec         x, vecs[2];
+  PetscScalar dots[2];
+  QPS_MPGP   *mpgp = (QPS_MPGP *)qps->data;
 
   PetscFunctionBegin;
   PetscCall(QPSGetSolvedQP(qps, &qp));
@@ -514,11 +514,11 @@ PetscErrorCode QPSSolve_MPGP(QPS qps)
     PetscCall(VecNorm(gP, NORM_2, &qps->rnorm)); /* qps->rnorm=norm(gP)*/
 
     /* compute dot products to control the proportionality */
-    PetscCall(VecDot(gc, gc, &gcTgc)); /* gcTgc=gc'*gc   */
+    PetscCall(VecDotRealPart(gc, gc, &gcTgc)); /* gcTgc=gc'*gc   */
     /* NOTE: using gf'*gf for proportiong rule instead of gr'*gf
     *  which can lead to more agressive proportioning as
     *  sqrt(g_reduced^T * g_free) <= ||g_free||                    */
-    PetscCall(VecDot(gf, gf, &gfTgf)); /* gfTgf=gr'*gf   */
+    PetscCall(VecDotRealPart(gf, gf, &gfTgf)); /* gfTgf=gr'*gf   */
 
     /* compute norm of gf, gc from computed dot products */
     if (qps->numbermonitors) {
@@ -538,10 +538,10 @@ PetscErrorCode QPSSolve_MPGP(QPS qps)
       nmv++;                        /* matrix multiplication counter */
 
       /* compute step-sizes */
-      PetscCall(VecDot(p, Ap, &pAp));        /* pAp=p'*Ap      */
-      PetscCall(VecDot(g, p, &acg));         /* acg=g'*p       */
-      acg = acg / pAp;                       /* acg=acg/pAp    */
-      PetscCall(QPCFeas(qpc, x, p, &afeas)); /* finds max.feas.steplength */
+      PetscCall(VecDotRealPart(p, Ap, &pAp)); /* pAp=p'*Ap      */
+      PetscCall(VecDotRealPart(g, p, &acg));  /* acg=g'*p       */
+      acg = acg / pAp;                        /* acg=acg/pAp    */
+      PetscCall(QPCFeas(qpc, x, p, &afeas));  /* finds max.feas.steplength */
 
       /* decide if it is able to do full CG step */
       if (acg <= afeas) {
@@ -555,10 +555,10 @@ PetscErrorCode QPSSolve_MPGP(QPS qps)
         PetscCall(MPGPGrads(qps, x, g)); /* grad. splitting  gP,gf,gc */
 
         /* compute orthogonalization parameter and next orthogonal vector */
-        PetscCall(VecDot(Ap, gf, &bcg)); /* bcg=Ap'*gf     */
-        bcg = bcg / pAp;                 /* bcg=bcg/pAp     */
-        PetscCall(VecAYPX(p, -bcg, gf)); /* p=gf-bcg*p     */
-      } else                             /* expansion step  */
+        PetscCall(VecDotRealPart(Ap, gf, &bcg)); /* bcg=Ap'*gf     */
+        bcg = bcg / pAp;                         /* bcg=bcg/pAp     */
+        PetscCall(VecAYPX(p, -bcg, gf));         /* p=gf-bcg*p     */
+      } else                                     /* expansion step  */
       {
         /* EXPANSION STEP */
         nexp++; /* increase expansion step counter */
@@ -585,10 +585,10 @@ PetscErrorCode QPSSolve_MPGP(QPS qps)
           if (f > fold) {
             nfinc++;
             if (mpgp->fallback2) {
-              PetscCall(MPGPGrads(qps, x, g));   /* grad. splitting  gP,gf,gc */
-              PetscCall(VecDot(gc, gc, &gcTgc)); /* gcTgc=gc'*gc   */
-              PetscCall(VecDot(gf, gf, &gfTgf)); /* gfTgf=gr'*gf   */
-              if (gcTgc <= gamma2 * gfTgf) {     /* u is proportional */
+              PetscCall(MPGPGrads(qps, x, g));           /* grad. splitting  gP,gf,gc */
+              PetscCall(VecDotRealPart(gc, gc, &gcTgc)); /* gcTgc=gc'*gc   */
+              PetscCall(VecDotRealPart(gf, gf, &gfTgf)); /* gfTgf=gr'*gf   */
+              if (gcTgc <= gamma2 * gfTgf) {             /* u is proportional */
                 mpgp->fallback = PETSC_FALSE;
               } else {
                 mpgp->fallback = PETSC_TRUE;
@@ -625,9 +625,9 @@ PetscErrorCode QPSSolve_MPGP(QPS qps)
       nmv++;                        /* matrix multiplication counter */
 
       /* compute step-size */
-      PetscCall(VecDot(p, Ap, &pAp)); /* pAp=p'*Ap       */
-      PetscCall(VecDot(g, p, &acg));  /* acg=g'*p        */
-      acg = acg / pAp;                /* acg=acg/pAp     */
+      PetscCall(VecDotRealPart(p, Ap, &pAp)); /* pAp=p'*Ap       */
+      PetscCall(VecDotRealPart(g, p, &acg));  /* acg=g'*p        */
+      acg = acg / pAp;                        /* acg=acg/pAp     */
 
       /* make a step */
       PetscCall(VecAXPY(x, -acg, p));  /* x=x-acg*p       */

--- a/src/qps/impls/smalxe/smalxe.c
+++ b/src/qps/impls/smalxe/smalxe.c
@@ -269,6 +269,7 @@ static PetscErrorCode QPSSMALXEUpdateNormBu_SMALXEON(QPS qps, Vec u, PetscReal *
   QP          qp_inner  = qps_inner->solQP;
   Mat         BtB;
   Vec         BtBu = qps->work[0];
+  PetscScalar dot;
 
   PetscFunctionBegin;
   PetscCall(MatPenalizedGetPenalizedTerm(qp_inner->A, &BtB));
@@ -277,8 +278,8 @@ static PetscErrorCode QPSSMALXEUpdateNormBu_SMALXEON(QPS qps, Vec u, PetscReal *
   PetscCall(QPSWorkVecStateUpdate(qps, 0));
   PetscCall(QPSSolutionVecStateUpdate(qps));
 
-  PetscCall(VecDot(u, BtBu, normBu)); /* normBu = u'*B'*B*u */
-  *normBu = PetscSqrtReal(*normBu);   /* normBu = sqrt(u'*B'*B*u) */
+  PetscCall(VecDot(u, BtBu, &dot));   /* normBu = u'*B'*B*u */
+  *normBu = PetscSqrtReal(dot);       /* normBu = sqrt(u'*B'*B*u) */
   *enorm  = *normBu / smalxe->rtol_E; /* enorm = norm(Bu)/rtol_E */
   PetscFunctionReturn(PETSC_SUCCESS);
 }

--- a/src/tests/ex3.c
+++ b/src/tests/ex3.c
@@ -3,9 +3,9 @@
 
 int main(int argc, char **args)
 {
-  Mat       A, Ainv;
-  PetscInt  i, n = 5, row[2], col[2], rstart, rend;
-  PetscReal val[] = {1.0, -1.0, -1.0, 1.0};
+  Mat         A, Ainv;
+  PetscInt    i, n = 5, row[2], col[2], rstart, rend;
+  PetscScalar val[] = {1.0, -1.0, -1.0, 1.0};
 
   PetscCall(PermonInitialize(&argc, &args, (char *)0, (char *)0));
   PetscCall(PetscOptionsGetInt(NULL, NULL, "-n", &n, NULL));

--- a/src/tutorials/ex1.c
+++ b/src/tutorials/ex1.c
@@ -47,13 +47,13 @@ PetscReal fobst(PetscInt i, PetscInt n)
 
 int main(int argc, char **args)
 {
-  Vec       b, c, x;
-  Mat       A;
-  QP        qp;
-  QPS       qps;
-  PetscInt  i, n = 10, col[3], rstart, rend;
-  PetscReal h, value[3];
-  PetscBool converged, viewSol = PETSC_FALSE;
+  Vec         b, c, x;
+  Mat         A;
+  QP          qp;
+  QPS         qps;
+  PetscInt    i, n = 10, col[3], rstart, rend;
+  PetscScalar h, value[3];
+  PetscBool   converged, viewSol = PETSC_FALSE;
 
   PetscCall(PermonInitialize(&argc, &args, (char *)0, help));
   PetscCall(PetscOptionsGetInt(NULL, NULL, "-n", &n, NULL));

--- a/src/tutorials/ex1.c
+++ b/src/tutorials/ex1.c
@@ -183,6 +183,7 @@ int main(int argc, char **args)
       suffix: projcg
       args: -qps_mpgp_expansion_type projcg
   testset:
+    requires: !complex
     suffix: gpcg
     nsize: {{1 3}}
     filter: grep -e CONVERGED -e Total -e Objective -e "r ="

--- a/src/tutorials/ex2.c
+++ b/src/tutorials/ex2.c
@@ -30,14 +30,14 @@ PetscReal fobst(PetscInt i, PetscInt n)
 
 int main(int argc, char **args)
 {
-  Vec       b, c, x;
-  Mat       A;
-  QP        qp;
-  QPS       qps;
-  IS        is = NULL;
-  PetscInt  i, n = 10, col[3], isn, rstart, rend;
-  PetscReal h, value[3];
-  PetscBool converged, infinite = PETSC_FALSE;
+  Vec         b, c, x;
+  Mat         A;
+  QP          qp;
+  QPS         qps;
+  IS          is = NULL;
+  PetscInt    i, n = 10, col[3], isn, rstart, rend;
+  PetscScalar h, value[3];
+  PetscBool   converged, infinite = PETSC_FALSE;
 
   PetscCall(PermonInitialize(&argc, &args, (char *)0, help));
   PetscCall(PetscOptionsGetInt(NULL, NULL, "-n", &n, NULL));

--- a/src/tutorials/ex3.c
+++ b/src/tutorials/ex3.c
@@ -31,13 +31,13 @@ PetscReal fobst(PetscInt i, PetscInt n)
 
 int main(int argc, char **args)
 {
-  Vec       b, c, x;
-  Mat       A, B, R = NULL;
-  QP        qp;
-  QPS       qps;
-  PetscInt  i, n = 10, col[3], rstart, rend;
-  PetscReal h, value[3];
-  PetscBool converged, spd = PETSC_FALSE, empty_nullsp = PETSC_FALSE;
+  Vec         b, c, x;
+  Mat         A, B, R = NULL;
+  QP          qp;
+  QPS         qps;
+  PetscInt    i, n = 10, col[3], rstart, rend;
+  PetscScalar h, value[3];
+  PetscBool   converged, spd = PETSC_FALSE, empty_nullsp = PETSC_FALSE;
 
   PetscCall(PermonInitialize(&argc, &args, (char *)0, help));
   PetscCall(PetscOptionsGetInt(NULL, NULL, "-n", &n, NULL));

--- a/src/tutorials/feti/ex1.c
+++ b/src/tutorials/feti/ex1.c
@@ -18,8 +18,8 @@ int main(int argc, char **args)
   Mat                    A;
   KSP                    ksp;
   Vec                    solution, rhs;
-  PetscReal              Aloc[4] = {1, -1, -1, 1};
-  PetscReal              bloc[2];
+  PetscScalar            Aloc[4] = {1, -1, -1, 1};
+  PetscScalar            bloc[2];
   PetscReal              h;
   PetscInt               ndofs_l, ndofs, ns, ne, ne_l = 3;
   PetscInt              *global_indices, idx[2];


### PR DESCRIPTION
support `--with-scalar-type=complex`
The input values should still have zero imaginary part. Solving complex QPs is not supported (can solve decomposed problem  R^{2n} -> R)